### PR TITLE
Update RelayCommand.cs

### DIFF
--- a/ModelsClassLibrary/RelayCommand.cs
+++ b/ModelsClassLibrary/RelayCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 
 namespace ModelsClassLibrary
@@ -10,11 +10,6 @@ namespace ModelsClassLibrary
 
         public event EventHandler CanExecuteChanged;
 
-        public void RaiseCanExecuteChanged()
-        {
-            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-        }
-
         public RelayCommand(Action execute, Func<bool> canExecute = null)
         {
             _execute = execute;
@@ -23,12 +18,17 @@ namespace ModelsClassLibrary
 
         public bool CanExecute(object parameter)
         {
-            return _canExecute != null ? _canExecute.Invoke() : true;
+            return _canExecute?.Invoke() ?? true;
         }
 
         public void Execute(object parameter)
         {
-            _execute.Invoke();
+            _execute?.Invoke();
+        }
+
+        public void RaiseCanExecuteChanged()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 }


### PR DESCRIPTION
Moved the RaiseCanExecuteChanged method below the other methods for better readability and consistency.

Simplified the CanExecute method implementation using the null conditional operator (?.).

Simplified the Execute method implementation using the null conditional operator (?.).

Added null checks before invoking the delegate methods (_execute and _canExecute) to prevent potential null reference exceptions.